### PR TITLE
Improve profile picture layout

### DIFF
--- a/_sass/profile.scss
+++ b/_sass/profile.scss
@@ -4,6 +4,7 @@
     height: fit-content;
     margin-bottom: 50px;
     padding-bottom: 10px;
+
     h1 {
         font-size: 50px;
         font-weight: 700;

--- a/_sass/profile.scss
+++ b/_sass/profile.scss
@@ -1,18 +1,20 @@
 .profile {
     background-color: #133667 !important;
     text-align: center;
-    height: 320px;
+    height: fit-content;
     margin-bottom: 50px;
+    padding-bottom: 10px;
     h1 {
         font-size: 50px;
         font-weight: 700;
         color: white;
+        margin: 0;
     }
     
     img {
         border-radius: 50%;
-        max-width: 100%;
-        max-height: 100%;
+        width: 200px;
+        height: 200px;
         margin-left: auto;
         margin-right: auto;
         display: inline;        
@@ -21,6 +23,8 @@
     
     .profile-picture {
         margin-bottom: 30px;
-        height: 200px;
+        height: fit-content;
     }
 }
+
+


### PR DESCRIPTION
Presently, the profile pictures at the top overflow when the screen is too narrow, or there are too many pictures. It affects the layout of the entire portfolio. 
This pull request fixes the layout by tweaking the `profile.scss` to prevent the overflow and adjust the layout of the profile section based on screen size or the number of images.

(Our Pod Leader knows we're working on this Pull Request.)