### PR TITLE
Add dark theme toggle

### DIFF
--- a/_includes/darkModeScript.html
+++ b/_includes/darkModeScript.html
@@ -1,0 +1,1 @@
+<script src="/assets/js/darkModeSwitch.js"></script>

--- a/_includes/navbar.html
+++ b/_includes/navbar.html
@@ -1,10 +1,15 @@
 <header class="nav-bar">
     <div class="nav-content">
         <a href="{{ '/' | relative_url }}">
-            <div class="nav-logo">
+            <div class="nav-logo mr-4">
                 <img src="./assets/img/mlh-prep.png" />
             </div>
         </a>
+
+        <div class="custom-control custom-switch ml-4">
+            <input type="checkbox" class="custom-control-input" id="dark-theme-toggle" />
+            <label class="custom-control-label" for="dark-theme-toggle">on</label>
+        </div>
         
     </div>
 </header>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -6,6 +6,8 @@
 
 <body>
     {{ content }}
+
+    {% include darkModeScript.html %}
 </body>
 
 </html>

--- a/_sass/all.scss
+++ b/_sass/all.scss
@@ -3,6 +3,7 @@
 @import 'navbar';
 @import 'profile';
 @import 'page';
+@import 'dark-mode';
 
 .card-container {
     display: grid;

--- a/_sass/dark-mode.scss
+++ b/_sass/dark-mode.scss
@@ -1,0 +1,25 @@
+[data-theme="dark"] {
+    background-color: #1C1C27 !important;
+  }
+
+  [data-theme="dark"] {
+    header, .profile, .banner {
+      background-color: #28293D !important;
+    }
+
+    h1, h2, .custom-control-label, .title {
+      color: #CFCFD4 !important;
+    }
+
+    .card {
+      background-color: #28293D !important;
+    }
+
+    .location {
+      color: #818497 !important;
+    }
+
+    .dates, p {
+      color: #818497 !important;
+    }
+  }

--- a/_sass/navbar.scss
+++ b/_sass/navbar.scss
@@ -6,6 +6,16 @@
     padding-top: 10px;
 }
 
+.nav-content {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.custom-control-label {
+    color: #ffffff;
+}
+
 .nav-content .logo-touch-target {
     display: inline-flex;
     height: 60%;

--- a/assets/js/darkModeSwitch.js
+++ b/assets/js/darkModeSwitch.js
@@ -1,0 +1,40 @@
+var darkSwitch = document.getElementById('dark-theme-toggle');
+window.addEventListener('load', function () {
+  initTheme();
+
+  if (darkSwitch !== null) {
+    darkSwitch.addEventListener('change', function () {
+      resetTheme();
+    });
+  }
+});
+
+/**
+ * Adds or removes the attribute 'data-theme' depending on whether
+ * the switch is 'on' or 'off'.
+ */
+function initTheme() {
+  var darkThemeSelected =
+    localStorage.getItem('darkSwitch') !== null &&
+    localStorage.getItem('darkSwitch') === 'dark';
+
+  if (darkSwitch !== null) darkSwitch.checked = darkThemeSelected;
+  darkThemeSelected
+    ? document.body.setAttribute('data-theme', 'dark')
+    : document.body.removeAttribute('data-theme');
+}
+
+/**
+ * Checks if the switch is 'on' or 'off'; if it is toggled,
+ * it will set the HTML attribute 'data-theme' to dark so the dark-theme CSS is
+ * applied.
+ */
+function resetTheme() {
+  if (darkSwitch.checked) {
+    document.body.setAttribute('data-theme', 'dark');
+    localStorage.setItem('darkSwitch', 'dark');
+  } else {
+    document.body.removeAttribute('data-theme');
+    localStorage.removeItem('darkSwitch');
+  }
+}

--- a/index.html
+++ b/index.html
@@ -12,6 +12,8 @@
     {% include description.html %}
     
     {% include projects.html %}
+
+    {% include darkModeScript.html %}
 </body>
 
 </html>


### PR DESCRIPTION
This PR (which addresses issue #16) adds a toggle switch in the navigation bar to swap the website to a dark theme. The switch is based on the Bootstrap theme, and it saves the user preference in the browser's local storage so that the light/dark theme is preserved on refresh and multiple visits to the portfolio.

P.S. The toggle switch is only present on the homepage of the portfolio, however, the theme is consistent on all the pages.

Glimpses:

<img width="600" alt="light-theme" src="https://user-images.githubusercontent.com/55343937/136067846-d6b46674-1348-4ae8-b0af-ce788814fca8.png">

<img width="600" alt="dark-theme" src="https://user-images.githubusercontent.com/55343937/136067926-610b8e53-50bf-4696-a789-dc097483663e.png">